### PR TITLE
Contract: Blacklist equity token manager

### DIFF
--- a/contracts/Payroll.sol
+++ b/contracts/Payroll.sol
@@ -335,8 +335,9 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
 
         // Add the Finance app to the blacklist to disallow employees from executing actions on the
         // Finance app from Payroll's context (since Payroll requires permissions on Finance)
-        address[] memory blacklist = new address[](1);
+        address[] memory blacklist = new address[](2);
         blacklist[0] = address(finance);
+        blacklist[1] = address(equityTokenManager);
 
         runScript(_evmScript, input, blacklist);
     }

--- a/contracts/Payroll.sol
+++ b/contracts/Payroll.sol
@@ -333,8 +333,8 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
         require(canForward(msg.sender, _evmScript), ERROR_CAN_NOT_FORWARD);
         bytes memory input = new bytes(0);
 
-        // Add the Finance app to the blacklist to disallow employees from executing actions on the
-        // Finance app from Payroll's context (since Payroll requires permissions on Finance)
+        // Add the Finance and Token Manager apps to the blacklist to disallow employees from executing actions on
+        // the apps from Payroll's context (since Payroll requires permissions on both apps)
         address[] memory blacklist = new address[](2);
         blacklist[0] = address(finance);
         blacklist[1] = address(equityTokenManager);


### PR DESCRIPTION
Blacklists `equityTokenManager` when forwarding actions to prevent employees from directly minting tokens by forwarding through Payroll.

Added a couple of tests for `EVMCALLS_BLACKLISTED_CALL`